### PR TITLE
fix: pass contentState through to decorators

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,11 +12,11 @@ function MultiDecorator(decorators) {
     @param {ContentBlock}
     @return {List<String>}
 */
-MultiDecorator.prototype.getDecorations = function(block) {
+MultiDecorator.prototype.getDecorations = function(block, contentState) {
     var decorations = Array(block.getText().length).fill(null);
 
     this.decorators.forEach(function(decorator, i) {
-        var _decorations = decorator.getDecorations(block);
+        var _decorations = decorator.getDecorations(block, contentState);
 
         _decorations.forEach(function(key, offset) {
             if (!key) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "immutable": "*"
   },
   "devDependencies": {
-    "draft-js": "^0.7.0",
+    "draft-js": "^0.10.0",
     "expect": "^1.20.1",
     "mocha": "^2.5.3",
     "react": "^15.1.0",

--- a/test/index.js
+++ b/test/index.js
@@ -8,12 +8,16 @@ describe('MultiDecorator', function() {
         text: 'AAA BBB CCC ABC'
     });
 
+    var firstDecoratorStrategy = expect.createSpy().andCall(
+        function(block, callback, contentState) {
+            callback(0, 3);
+            callback(12, 15);
+        }
+    )
+
     var firstDecorator = new Draft.CompositeDecorator([
         {
-            strategy: function(block, callback) {
-                callback(0, 3);
-                callback(12, 15);
-            },
+            strategy: firstDecoratorStrategy,
             component: function() { return 'a'; }
         }
     ]);
@@ -43,6 +47,14 @@ describe('MultiDecorator', function() {
         secondDecorator,
         thirdDecorator
     ]);
+
+    it('should pass contentState through to decorators', function() {
+        const contentState = 'mockContentState'
+        decorator.getDecorations(block, contentState);
+        expect(firstDecoratorStrategy.calls[0].arguments[0]).toBe(block)
+        expect(firstDecoratorStrategy.calls[0].arguments[2]).toBe(contentState)
+        firstDecoratorStrategy.reset()
+    })
 
     it('should correctly decorate text', function() {
         var out = decorator.getDecorations(block);


### PR DESCRIPTION
Adds support for DraftJS v0.10.0, which expects contentState to be passed in to each decorator.

See https://facebook.github.io/draft-js/docs/v0-10-api-migration.html and https://github.com/facebook/draft-js/blob/master/src/model/decorators/DraftDecoratorType.js.